### PR TITLE
Conflict with env var DEBUG

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ function factory(name, options) {
  */
 function enabled(name) {
   var envy = env()
-    , variable = envy.debug || envy.diagnostics || '';
+    , variable = envy.diagnostics || envy.debug || '';
 
   if (!variable) return false;
 


### PR DESCRIPTION
Like many, in my project I have both `diagnostics` and `debug`. I saw that you provide the option for env.diagnostics and since it's more specific it would be better to have priority over the more generic env.debug.

Just FYI my issue was that I'm using `DEBUG=*,-this,-that` which returns always makes `enabled(...)` return `true` due to the `*`.

Cheers
